### PR TITLE
Update winit and wgpu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1.70 as build_canvas_app
+FROM rust:1.77 as build_canvas_app
 WORKDIR /usr/src/DoodlingCanvas
 COPY ./DoodlingCanvas .
 RUN cargo install wasm-pack
 RUN wasm-pack build --release --target web
 
-FROM rust:1.70 as build_service
+FROM rust:1.77 as build_service
 
 WORKDIR /usr/src/DoodlingServer
 COPY ./DoodlingServer .

--- a/DoodlingCanvas/Cargo.toml
+++ b/DoodlingCanvas/Cargo.toml
@@ -21,5 +21,5 @@ pollster = "0.3.0"
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.37"
 web-sys = { version = "0.3.64", features = ["Document", "Window", "Element"] }
-wgpu = { version = "0.17.0", features = ["webgl"] }
-winit = "0.28.6"
+wgpu = { version = "0.20.0", features = ["webgl"] }
+winit = "0.30.0"

--- a/DoodlingCanvas/Cargo.toml
+++ b/DoodlingCanvas/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+winit = "0.30.0"
 anyhow = "1.0.75"
 base64 = "0.21.3"
 bytemuck = { version = "1.13.1", features = ["derive"] }
@@ -22,4 +23,3 @@ wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.37"
 web-sys = { version = "0.3.64", features = ["Document", "Window", "Element"] }
 wgpu = { version = "0.20.0", features = ["webgl"] }
-winit = "0.30.0"

--- a/DoodlingCanvas/Cargo.toml
+++ b/DoodlingCanvas/Cargo.toml
@@ -19,7 +19,7 @@ futures-intrusive = "0.5.0"
 image = "0.24.7"
 log = "0.4.20"
 pollster = "0.3.0"
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4.37"
+wasm-bindgen = "0.2.92"
+wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.64", features = ["Document", "Window", "Element"] }
 wgpu = { version = "0.20.0", features = ["webgl"] }

--- a/DoodlingCanvas/src/lib.rs
+++ b/DoodlingCanvas/src/lib.rs
@@ -1,134 +1,49 @@
 #![allow(non_snake_case)]
-mod render_state;
 mod brush;
+mod render_state;
 pub mod utils;
-use std::sync::{Arc, Mutex};
-
-use image::{codecs::png::PngEncoder, EncodableLayout};
-use log::info;
-use utils::{WINDOW_HEIGHT, WINDOW_WIDTH};
-use base64::{engine::general_purpose::STANDARD, Engine};
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
-use winit::{
-    event::*,
-    event_loop::{ControlFlow, EventLoop, EventLoopProxy, EventLoopBuilder},
-    window::{WindowBuilder, Window}, dpi::PhysicalSize,
+pub mod winit_app;
+use std::{
+    borrow::BorrowMut,
+    sync::{Arc, Mutex},
 };
 
-use crate::{render_state::State, brush::Rectangle};
-#[derive(Debug)]
-enum Events{
-    Close
-}
+use base64::{engine::general_purpose::STANDARD, Engine};
+use image::{codecs::png::PngEncoder, EncodableLayout};
+use log::info;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+use winit::event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopProxy};
+use winit_app::{CanvasApp, Events};
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub struct WindowHandler
-{
-    renderer: Arc<Mutex<State>>,
+pub struct WindowHandler<'a> {
     event_loop: Arc<Mutex<Option<EventLoop<Events>>>>,
-    event_loop_proxy: Arc<Mutex<EventLoopProxy<Events>>>
+    event_loop_proxy: Arc<Mutex<EventLoopProxy<Events>>>,
+    app: CanvasApp<'a>,
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl WindowHandler
-{
+impl<'a> WindowHandler<'a> {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn new(other : &WindowHandler) -> Self
-    {
-        Self
-        {
-            renderer: other.renderer.clone(),
+    pub fn new(other: &Self) -> Self {
+        Self {
             event_loop: other.event_loop.clone(),
-            event_loop_proxy: other.event_loop_proxy.clone()
+            event_loop_proxy: other.event_loop_proxy.clone(),
+            app: other.app.clone(),
         }
     }
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn run_window_loop(self)
-    {
+    pub fn run_window_loop(mut self) {
         info!("Setup window loop");
         let event_loop = self.event_loop.lock().unwrap().take().unwrap();
-        let mut mouse_position = (0.0, 0.0);
-        let mut mouse_pressed : ElementState = ElementState::Released;
-        let state_window_id = {self.renderer.lock().unwrap().window().id()};
-        {
-            let mut renderer = self.renderer.lock().unwrap();
-            let mut clear_screen = renderer.begin_render();
-            renderer.clear_screen(&mut clear_screen);
-            renderer.end_render(clear_screen);
-        }
         info!("Running loop");
-
-        let mut rect = {
-        let mut state = self.renderer.lock().unwrap();
-        Rectangle::new(&mut state,[0.0,0.0,10.0,10.0])
-        };
-        event_loop.run(move |event, _, control_flow| {
-        match event {
-            Event::WindowEvent {
-                ref event,
-                window_id,
-            } if window_id == state_window_id => match event {
-                WindowEvent::CloseRequested
-                | WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            state: ElementState::Pressed,
-                            virtual_keycode: Some(VirtualKeyCode::Escape),
-                            ..
-                        },
-                    ..
-                } => {*control_flow = ControlFlow::Exit},
-                WindowEvent::MouseInput{
-                    button:MouseButton::Left,
-                    ..
-                } => {
-                    let WindowEvent::MouseInput{state : pressed,..} = *event else{unimplemented!()};
-                    mouse_pressed = pressed;
-                },
-                WindowEvent::MouseInput {state: ElementState::Pressed, button: MouseButton::Right,..} =>
-                {
-                }
-
-                WindowEvent::CursorMoved{position,..} => {
-                    mouse_position = (position.x as f32, position.y as f32);
-                },
-                _ => {}
-            },
-            Event::RedrawRequested(window_id) if window_id == state_window_id => {
-                let mut renderer = self.renderer.lock().unwrap();
-                if mouse_pressed == ElementState::Pressed {
-                    let mut paint = renderer.begin_render();
-                    rect.draw_to( &mut renderer, &mut paint,[mouse_position.0,mouse_position.1]);
-                    renderer.end_render(paint);
-                }
-                match renderer.render() {
-                    Ok(_) => {}
-                    // Reconfigure the surface if lost
-                    Err(wgpu::SurfaceError::Lost) => {},
-                    // The system is out of memory, we should probably quit
-                    Err(wgpu::SurfaceError::OutOfMemory) => *control_flow = ControlFlow::Exit,
-                    // All other errors (Outdated, Timeout) should be resolved by the next frame
-                    Err(e) => eprintln!("{:?}", e),
-                }
-            },
-            Event::MainEventsCleared => {
-                // RedrawRequested will only trigger once, unless we manually
-                // request it.
-                let renderer = self.renderer.lock().unwrap();
-                renderer.window().request_redraw();
-            },
-            Event::UserEvent(Events::Close) => {
-                info!("Received close event,sending exit signal");
-                *control_flow = ControlFlow::Exit;
-            }
-            _ => {}
-        }
-        });
+        let _ = event_loop.run_app(&mut self.app);
     }
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn get_canvas_capture(&self) -> String
-    {
-        let img = pollster::block_on(self.renderer.lock().unwrap().extract_framebuffer());
+    pub fn get_canvas_capture(&self) -> String {
+        let rendptr = self.app.renderer();
+        let img = pollster::block_on(rendptr.lock().unwrap().extract_framebuffer());
         let mut buffer = Vec::new();
         let encoder = PngEncoder::new(&mut buffer);
         img.write_with_encoder(encoder).unwrap();
@@ -137,16 +52,18 @@ impl WindowHandler
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn close(&self)
-    {
+    pub fn close(&self) {
         info!("Sending close event");
-        self.event_loop_proxy.lock().unwrap().send_event(Events::Close).expect("Failed to send close event");
+        self.event_loop_proxy
+            .lock()
+            .unwrap()
+            .send_event(Events::Close)
+            .expect("Failed to send close event");
     }
-
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub async fn create_window() -> WindowHandler {
+pub fn create_window<'a>() -> WindowHandler<'a> {
     cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
@@ -156,40 +73,17 @@ pub async fn create_window() -> WindowHandler {
     }
     }
     info!("Creating window");
-    let event_loop = EventLoopBuilder::<Events>::with_user_event().build();
+    let event_loop = EventLoop::<Events>::with_user_event()
+        .build()
+        .expect("Failed to create event loop");
     let proxy = event_loop.create_proxy();
-    let window: Window = WindowBuilder::new().build(&event_loop).unwrap();
-    window.set_inner_size(PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT));
-    #[cfg(target_arch = "wasm32")]
-    {
-        // Winit prevents sizing with CSS, so we have to set
-        // the size manually when on web.
-        info!("Initializing canvas");
-        use winit::platform::web::WindowExtWebSys;
-        web_sys::window()
-            .and_then(|win| win.document())
-            .and_then(|doc| {
-                let dst = doc.get_element_by_id("wasm-example")?;
-                let canvas = web_sys::Element::from(window.canvas());
-                dst.append_child(&canvas).ok()?;
-                Some(())
-            })
-            .expect("Couldn't append canvas to document body.");
-    }
-    let state = Arc::new(Mutex::new(State::new(window).await));
-    WindowHandler
-    {
-        renderer: state,
-        event_loop : Arc::new(Mutex::new(Some(event_loop))),
-        event_loop_proxy: Arc::new(Mutex::new(proxy))
-    }
 
+    WindowHandler {
+        event_loop: Arc::new(Mutex::new(Some(event_loop))),
+        event_loop_proxy: Arc::new(Mutex::new(proxy)),
+        app: CanvasApp::default(),
+    }
 }
-
-
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-fn _entry_point()
-{
-
-}
+fn _entry_point() {}

--- a/DoodlingCanvas/src/lib.rs
+++ b/DoodlingCanvas/src/lib.rs
@@ -3,17 +3,14 @@ mod brush;
 mod render_state;
 pub mod utils;
 pub mod winit_app;
-use std::{
-    borrow::BorrowMut,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use image::{codecs::png::PngEncoder, EncodableLayout};
 use log::info;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
-use winit::event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopProxy};
+use winit::event_loop::{EventLoop, EventLoopProxy};
 use winit_app::{CanvasApp, Events};
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]

--- a/DoodlingCanvas/src/lib.rs
+++ b/DoodlingCanvas/src/lib.rs
@@ -23,7 +23,7 @@ pub struct WindowHandler {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 impl WindowHandler {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn new(other: &Self) -> Self {
+    pub fn new(other: &WindowHandler) -> Self {
         Self {
             event_loop: other.event_loop.clone(),
             event_loop_proxy: other.event_loop_proxy.clone(),
@@ -78,10 +78,11 @@ pub fn create_window() -> WindowHandler {
         .expect("Failed to create event loop");
     let proxy = event_loop.create_proxy();
 
+    let event_loop_proxy = Arc::new(Mutex::new(proxy));
     WindowHandler {
         event_loop: Arc::new(Mutex::new(Some(event_loop))),
-        event_loop_proxy: Arc::new(Mutex::new(proxy)),
-        app: CanvasApp::default(),
+        event_loop_proxy: event_loop_proxy.clone(),
+        app: CanvasApp::new(event_loop_proxy.clone()),
     }
 }
 

--- a/DoodlingCanvas/src/lib.rs
+++ b/DoodlingCanvas/src/lib.rs
@@ -14,14 +14,14 @@ use winit::event_loop::{EventLoop, EventLoopProxy};
 use winit_app::{CanvasApp, Events};
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub struct WindowHandler<'a> {
+pub struct WindowHandler {
     event_loop: Arc<Mutex<Option<EventLoop<Events>>>>,
     event_loop_proxy: Arc<Mutex<EventLoopProxy<Events>>>,
-    app: CanvasApp<'a>,
+    app: CanvasApp,
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl<'a> WindowHandler<'a> {
+impl WindowHandler {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn new(other: &Self) -> Self {
         Self {
@@ -39,6 +39,9 @@ impl<'a> WindowHandler<'a> {
     }
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn get_canvas_capture(&self) -> String {
+        if self.app.state.is_none() {
+            return String::from("");
+        }
         let rendptr = self.app.renderer();
         let img = pollster::block_on(rendptr.lock().unwrap().extract_framebuffer());
         let mut buffer = Vec::new();
@@ -60,7 +63,7 @@ impl<'a> WindowHandler<'a> {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub fn create_window<'a>() -> WindowHandler<'a> {
+pub fn create_window() -> WindowHandler {
     cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));

--- a/DoodlingCanvas/src/lib.rs
+++ b/DoodlingCanvas/src/lib.rs
@@ -31,11 +31,12 @@ impl WindowHandler {
         }
     }
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn run_window_loop(mut self) {
+    pub fn run_window_loop(self) {
+        use winit::platform::web::EventLoopExtWebSys;
         info!("Setup window loop");
         let event_loop = self.event_loop.lock().unwrap().take().unwrap();
         info!("Running loop");
-        let _ = event_loop.run_app(&mut self.app);
+        let _ = event_loop.spawn_app(self.app);
     }
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn get_canvas_capture(&self) -> String {
@@ -67,7 +68,7 @@ pub fn create_window() -> WindowHandler {
     cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
-        console_log::init_with_level(log::Level::Info);
+        console_log::init_with_level(log::Level::Info).expect("Failed to initialize logger");
     } else {
         env_logger::init();
     }

--- a/DoodlingCanvas/src/main.rs
+++ b/DoodlingCanvas/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
-use DoodlingCanvas::{create_window};
+use DoodlingCanvas::create_window;
 
 fn main() {
-    let window = pollster::block_on(create_window());
+    let window = create_window();
     window.run_window_loop();
 }

--- a/DoodlingCanvas/src/render_state.rs
+++ b/DoodlingCanvas/src/render_state.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+use std::fmt::Formatter;
 use std::sync::Arc;
 
 use crate::utils;
@@ -27,8 +29,8 @@ impl Vertex {
         }
     }
 }
-pub struct State<'a> {
-    surface: wgpu::Surface<'a>,
+pub struct State {
+    surface: wgpu::Surface<'static>,
     device: wgpu::Device,
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
@@ -43,7 +45,7 @@ pub struct State<'a> {
 }
 
 pub type RenderCommands = CommandEncoder;
-impl<'a> State<'a> {
+impl State {
     const CLEAR_COLOR: wgpu::Color = wgpu::Color {
         r: 0.2,
         g: 0.2,
@@ -497,5 +499,14 @@ impl<'a> State<'a> {
             multiview: None, // 5.
         };
         device.create_render_pipeline(&screen_pipeline_descriptor)
+    }
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("State")
+            .field("size", &self.size)
+            .field("window", &self.window)
+            .finish()
     }
 }

--- a/DoodlingCanvas/src/render_state.rs
+++ b/DoodlingCanvas/src/render_state.rs
@@ -1,8 +1,13 @@
-use image::GenericImage;
-use wgpu::{CommandEncoder, Device, RenderPipeline, TextureFormat, ShaderModule, BindGroupLayout, VertexBufferLayout};
-use winit::window::Window;
-use wgpu::util::DeviceExt;
+use std::sync::Arc;
+
 use crate::utils;
+use image::GenericImage;
+use wgpu::util::DeviceExt;
+use wgpu::{
+    BindGroupLayout, CommandEncoder, Device, PipelineCompilationOptions, RenderPipeline,
+    ShaderModule, TextureFormat, VertexBufferLayout,
+};
+use winit::window::Window;
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Vertex {
@@ -10,8 +15,7 @@ pub struct Vertex {
 }
 
 impl Vertex {
-    const ATTRIBS: [wgpu::VertexAttribute; 1] =
-        wgpu::vertex_attr_array![0 => Float32x2];
+    const ATTRIBS: [wgpu::VertexAttribute; 1] = wgpu::vertex_attr_array![0 => Float32x2];
 
     fn desc() -> wgpu::VertexBufferLayout<'static> {
         use std::mem;
@@ -23,116 +27,124 @@ impl Vertex {
         }
     }
 }
-pub struct State {
-    surface: wgpu::Surface,
+pub struct State<'a> {
+    surface: wgpu::Surface<'a>,
     device: wgpu::Device,
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
     pub size: winit::dpi::PhysicalSize<u32>,
-    pub window: Window,
+    pub window: Arc<Window>,
     display_render_pipeline: wgpu::RenderPipeline,
     canvas_texture: wgpu::Texture,
     canvas_render_pipeline: wgpu::RenderPipeline,
     canvas_bind_group: wgpu::BindGroup,
     offset_bind_group: wgpu::BindGroup,
-    drawing_offset_buffer: wgpu::Buffer
+    drawing_offset_buffer: wgpu::Buffer,
 }
 
 pub type RenderCommands = CommandEncoder;
-impl State {
-    const CLEAR_COLOR : wgpu::Color = wgpu::Color {
+impl<'a> State<'a> {
+    const CLEAR_COLOR: wgpu::Color = wgpu::Color {
         r: 0.2,
         g: 0.2,
         b: 0.2,
         a: 1.0,
     };
     // Creating some of the wgpu types requires async code
-pub async fn new(window: Window) -> Self {
-    let size = window.inner_size();
+    pub async fn new(window: Arc<Window>) -> Self {
+        let size = window.inner_size();
 
-    // The instance is a handle to our GPU
-    // Backends::all => Vulkan + Metal + DX12 + Browser WebGPU
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::all(),
-        dx12_shader_compiler: Default::default(),
-    });
-    // # Safety
-    //
-    // The surface needs to live as long as the window that created it.
-    // State owns the window so this should be safe.
-    let surface = unsafe { instance.create_surface(&window) }.unwrap();
+        // The instance is a handle to our GPU
+        // Backends::all => Vulkan + Metal + DX12 + Browser WebGPU
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            dx12_shader_compiler: Default::default(),
+            flags: Default::default(),
+            gles_minor_version: Default::default(),
+        });
+        // # Safety
+        //
+        // The surface needs to live as long as the window that created it.
+        // State owns the window so this should be safe.
+        let surface = instance.create_surface(window.clone()).unwrap();
 
-    let adapter = instance
-    .enumerate_adapters(wgpu::Backends::all())
-    .find(|adapter| {
-        // Check if this adapter supports our surface
-        adapter.is_surface_supported(&surface)
-    })
-    .unwrap();
-    let (device, queue) = adapter.request_device(
-        &wgpu::DeviceDescriptor {
-            features: wgpu::Features::empty(),
-            // WebGL doesn't support all of wgpu's features, so if
-            // we're building for the web we'll have to disable some.
-            limits: if cfg!(target_arch = "wasm32") {
-                wgpu::Limits::downlevel_webgl2_defaults()
-            } else {
-                wgpu::Limits::default()
+        let adapters = instance.enumerate_adapters(wgpu::Backends::all());
+        let adapter = adapters
+            .iter()
+            .find(|adapter| {
+                // Check if this adapter supports our surface
+                adapter.is_surface_supported(&surface)
+            })
+            .unwrap();
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    required_features: wgpu::Features::empty(),
+                    // WebGL doesn't support all of wgpu's features, so if
+                    // we're building for the web we'll have to disable some.
+                    required_limits: if cfg!(target_arch = "wasm32") {
+                        wgpu::Limits::downlevel_webgl2_defaults()
+                    } else {
+                        wgpu::Limits::default()
+                    },
+                    label: None,
+                },
+                None, // Trace path
+            )
+            .await
+            .unwrap();
+        let surface_caps = surface.get_capabilities(&adapter);
+        let surface_format = surface_caps
+            .formats
+            .iter()
+            .copied()
+            .find(|f| f.is_srgb())
+            .unwrap_or(surface_caps.formats[0]);
+
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: surface_format,
+            width: size.width,
+            height: size.height,
+            present_mode: surface_caps.present_modes[0],
+            alpha_mode: surface_caps.alpha_modes[0],
+            view_formats: vec![],
+            desired_maximum_frame_latency: 1,
+        };
+        surface.configure(&device, &config);
+
+        let render_shader = device.create_shader_module(wgpu::include_wgsl!("render_shader.wgsl"));
+        let canvas_shader = device.create_shader_module(wgpu::include_wgsl!("canvas_shader.wgsl"));
+        //The canvas texture
+        let texture_desc = wgpu::TextureDescriptor {
+            size: wgpu::Extent3d {
+                width: utils::WINDOW_WIDTH,
+                height: utils::WINDOW_HEIGHT,
+                depth_or_array_layers: 1,
             },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            usage: wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST,
             label: None,
-        },
-        None, // Trace path
-    ).await.unwrap();
-    let surface_caps = surface.get_capabilities(&adapter);
-    let surface_format = surface_caps.formats.iter()
-        .copied()
-        .find(|f| f.is_srgb())
-        .unwrap_or(surface_caps.formats[0]);
-
-    let config = wgpu::SurfaceConfiguration {
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: surface_format,
-        width: size.width,
-        height: size.height,
-        present_mode: surface_caps.present_modes[0],
-        alpha_mode: surface_caps.alpha_modes[0],
-        view_formats: vec![],
-    };
-    surface.configure(&device, &config);
-
-    let render_shader = device.create_shader_module(wgpu::include_wgsl!("render_shader.wgsl"));
-    let canvas_shader = device.create_shader_module(wgpu::include_wgsl!("canvas_shader.wgsl"));
-    //The canvas texture
-    let texture_desc = wgpu::TextureDescriptor {
-        size: wgpu::Extent3d {
-            width: utils::WINDOW_WIDTH,
-            height: utils::WINDOW_HEIGHT,
-            depth_or_array_layers: 1,
-        },
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Rgba8UnormSrgb,
-        usage: wgpu::TextureUsages::COPY_SRC
-            | wgpu::TextureUsages::RENDER_ATTACHMENT
-            | wgpu::TextureUsages::TEXTURE_BINDING
-            | wgpu::TextureUsages::COPY_DST
-            ,
-        label: None,
-        view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
-    };
-    let texture = device.create_texture(&texture_desc);
-    let canvas_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-    let canvas_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-        address_mode_u: wgpu::AddressMode::ClampToEdge,
-        address_mode_v: wgpu::AddressMode::ClampToEdge,
-        address_mode_w: wgpu::AddressMode::ClampToEdge,
-        mag_filter: wgpu::FilterMode::Linear,
-        min_filter: wgpu::FilterMode::Nearest,
-        mipmap_filter: wgpu::FilterMode::Nearest,
-        ..Default::default()
-    });
-    let texture_bind_group_layout =
+            view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
+        };
+        let texture = device.create_texture(&texture_desc);
+        let canvas_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let canvas_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+        let texture_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 entries: &[
                     wgpu::BindGroupLayoutEntry {
@@ -156,33 +168,29 @@ pub async fn new(window: Window) -> Self {
                 ],
                 label: Some("texture_bind_group_layout"),
             });
-    let canvas_bind_group = device.create_bind_group(
-    &wgpu::BindGroupDescriptor {
-        layout: &texture_bind_group_layout,
-        entries: &[
-            wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::TextureView(&canvas_view),
-            },
-            wgpu::BindGroupEntry {
-                binding: 1,
-                resource: wgpu::BindingResource::Sampler(&canvas_sampler),
-            }
-        ],
-        label: Some("diffuse_bind_group"),
-    }
-    );
-    let offset_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("Offset Buffer"),
-        contents: bytemuck::cast_slice(&[0.0f32,0.0f32,0.0f32,0.0f32]),
-        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-    });
-    let offset_bind_group_layout = device.create_bind_group_layout(
-        &wgpu::BindGroupLayoutDescriptor
-        {
-            label: Some("Offset Buffer Layout"),
+        let canvas_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &texture_bind_group_layout,
             entries: &[
-                wgpu::BindGroupLayoutEntry{
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&canvas_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&canvas_sampler),
+                },
+            ],
+            label: Some("diffuse_bind_group"),
+        });
+        let offset_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Offset Buffer"),
+            contents: bytemuck::cast_slice(&[0.0f32, 0.0f32, 0.0f32, 0.0f32]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let offset_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Offset Buffer Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStages::VERTEX,
                     ty: wgpu::BindingType::Buffer {
@@ -191,118 +199,142 @@ pub async fn new(window: Window) -> Self {
                         min_binding_size: None,
                     },
                     count: None,
-                }
-            ],
-        }
-    );
-    let offset_bind_group = device.create_bind_group(
-        &wgpu::BindGroupDescriptor
-        {
+                }],
+            });
+        let offset_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("Offset Bind Group"),
             layout: &offset_bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry{
-                    binding: 0,
-                    resource: offset_buffer.as_entire_binding(),
-                }
-            ],
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: offset_buffer.as_entire_binding(),
+            }],
+        });
+        let render_pipeline: RenderPipeline = Self::create_pipeline(
+            &device,
+            config.format,
+            render_shader,
+            &[&texture_bind_group_layout],
+            &[],
+        );
+        let canvas_render_pipeline: RenderPipeline = Self::create_pipeline(
+            &device,
+            wgpu::TextureFormat::Rgba8UnormSrgb,
+            canvas_shader,
+            &[&offset_bind_group_layout],
+            &[Vertex::desc()],
+        );
+        Self {
+            window,
+            surface,
+            device,
+            queue,
+            config,
+            size,
+            display_render_pipeline: render_pipeline,
+            canvas_texture: texture,
+            canvas_render_pipeline,
+            canvas_bind_group,
+            offset_bind_group,
+            drawing_offset_buffer: offset_buffer,
         }
-    );
-    let render_pipeline: RenderPipeline = Self::create_pipeline(&device, config.format, render_shader,&[&texture_bind_group_layout],&[]);
-    let canvas_render_pipeline: RenderPipeline = Self::create_pipeline(&device, wgpu::TextureFormat::Rgba8UnormSrgb, canvas_shader,&[&offset_bind_group_layout],&[Vertex::desc()]);
-    Self {
-        window,
-        surface,
-        device,
-        queue,
-        config,
-        size,
-        display_render_pipeline: render_pipeline,
-        canvas_texture: texture,
-        canvas_render_pipeline,
-        canvas_bind_group,
-        offset_bind_group,
-        drawing_offset_buffer: offset_buffer,
     }
-}
-
 
     pub fn window(&self) -> &Window {
         &self.window
     }
     pub fn begin_render(&mut self) -> RenderCommands {
-        self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-         label: Some("Render Encoder"),
-        })
+        self.device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            })
     }
-    pub fn end_render(&mut self, commands: RenderCommands)
-    {
+    pub fn end_render(&mut self, commands: RenderCommands) {
         self.queue.submit(std::iter::once(commands.finish()));
     }
 
-    pub fn clear_screen(&mut self, commands: &mut RenderCommands)
-    {
+    pub fn clear_screen(&mut self, commands: &mut RenderCommands) {
         let color_attachment_operation = wgpu::Operations {
             load: wgpu::LoadOp::Clear(Self::CLEAR_COLOR),
-            store: true,
+            store: wgpu::StoreOp::Store,
         };
         {
-        let view = self.canvas_texture.create_view(&wgpu::TextureViewDescriptor::default());
-        let mut render_pass = commands.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("Clear Canvas Render Pass"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &view,
-                resolve_target: None,
-                ops: color_attachment_operation,
-            })],
-            depth_stencil_attachment: None,
-        });
+            let view = self
+                .canvas_texture
+                .create_view(&wgpu::TextureViewDescriptor::default());
+            let mut render_pass = commands.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Clear Canvas Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: color_attachment_operation,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
 
-        render_pass.set_pipeline(&self.canvas_render_pipeline);
+            render_pass.set_pipeline(&self.canvas_render_pipeline);
         }
     }
 
-    pub fn draw_buffer(&mut self,commands: &mut RenderCommands, buffer : &wgpu::Buffer, offset : [f32;2])
-    {
+    pub fn draw_buffer(
+        &mut self,
+        commands: &mut RenderCommands,
+        buffer: &wgpu::Buffer,
+        offset: [f32; 2],
+    ) {
         let color_attachment_operation = wgpu::Operations {
             load: wgpu::LoadOp::Load,
-            store: true,
+            store: wgpu::StoreOp::Store,
         };
         {
-        self.queue.write_buffer(&self.drawing_offset_buffer, 0, bytemuck::cast_slice(&offset));
-        let view = self.canvas_texture.create_view(&wgpu::TextureViewDescriptor::default());
-        let mut render_pass = commands.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("Draw Buffer Render Pass"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &view,
-                resolve_target: None,
-                ops: color_attachment_operation,
-            })],
-            depth_stencil_attachment: None,
-        });
+            self.queue.write_buffer(
+                &self.drawing_offset_buffer,
+                0,
+                bytemuck::cast_slice(&offset),
+            );
+            let view = self
+                .canvas_texture
+                .create_view(&wgpu::TextureViewDescriptor::default());
+            let mut render_pass = commands.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Draw Buffer Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: color_attachment_operation,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
 
-        render_pass.set_pipeline(&self.canvas_render_pipeline);
-        render_pass.set_vertex_buffer(0, buffer.slice(..));
-        render_pass.set_bind_group(0, &self.offset_bind_group, &[]);
-        render_pass.draw(0..6, 0..1);
+            render_pass.set_pipeline(&self.canvas_render_pipeline);
+            render_pass.set_vertex_buffer(0, buffer.slice(..));
+            render_pass.set_bind_group(0, &self.offset_bind_group, &[]);
+            render_pass.draw(0..6, 0..1);
         }
     }
     //Creates a buffer for this state, which can be used to draw to the screen
-    pub fn make_test_buffer(&mut self,vertices : &[Vertex]) -> wgpu::Buffer
-    {
-        let vertex_buffer = self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Vertex Buffer"),
-            contents: bytemuck::cast_slice(&vertices),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
+    pub fn make_test_buffer(&mut self, vertices: &[Vertex]) -> wgpu::Buffer {
+        let vertex_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Vertex Buffer"),
+                contents: bytemuck::cast_slice(&vertices),
+                usage: wgpu::BufferUsages::VERTEX,
+            });
         vertex_buffer
     }
     pub fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
         let output = self.surface.get_current_texture()?;
-        let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
-        let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-         label: Some("Render Encoder"),
-        });
+        let view = output
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            });
         let color_attachment_operation = wgpu::Operations {
             load: wgpu::LoadOp::Clear(wgpu::Color {
                 r: 1.0,
@@ -310,21 +342,23 @@ pub async fn new(window: Window) -> Self {
                 b: 1.0,
                 a: 1.0,
             }),
-            store: true,
+            store: wgpu::StoreOp::Store,
         };
         {
-        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("Render Pass"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &view,
-                resolve_target: None,
-                ops: color_attachment_operation,
-            })],
-            depth_stencil_attachment: None,
-        });
-        render_pass.set_pipeline(&self.display_render_pipeline);
-        render_pass.set_bind_group(0, &self.canvas_bind_group, &[]);
-        render_pass.draw(0..6,0..1);
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: color_attachment_operation,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            render_pass.set_pipeline(&self.display_render_pipeline);
+            render_pass.set_bind_group(0, &self.canvas_bind_group, &[]);
+            render_pass.draw(0..6, 0..1);
         }
         // submit will accept anything that implements IntoIter
         self.queue.submit(std::iter::once(encoder.finish()));
@@ -333,22 +367,22 @@ pub async fn new(window: Window) -> Self {
         Ok(())
     }
     //The buffer for the copy operation must have the width a multiple of 256
-    fn get_necessary_buffer_width(width : u32) -> u32
-    {
+    fn get_necessary_buffer_width(width: u32) -> u32 {
         //TODO: replace chatgpt code here
         let mut necessary_width = width;
-        while necessary_width % 256 != 0
-        {
+        while necessary_width % 256 != 0 {
             necessary_width += 1;
         }
         necessary_width
     }
     //EXTRACTS THE FRAMEBUFFER FROM THE GPU, THE FORMAT IS NOT DEFINED YET(considered BGRA8Srgb for now)
     //Since this is intended to only be called at the end of the program(and only once) it should be fine to allocate the buffer here
-    pub async fn extract_framebuffer(& self) -> image::RgbaImage
-    {
+    pub async fn extract_framebuffer(&self) -> image::RgbaImage {
         let u32_size = std::mem::size_of::<u32>() as u32;
-        let output_buffer_size = (u32_size * utils::WINDOW_HEIGHT * Self::get_necessary_buffer_width(utils::WINDOW_WIDTH)) as wgpu::BufferAddress;
+        let output_buffer_size = (u32_size
+            * utils::WINDOW_HEIGHT
+            * Self::get_necessary_buffer_width(utils::WINDOW_WIDTH))
+            as wgpu::BufferAddress;
         let output_buffer_desc = wgpu::BufferDescriptor {
             size: output_buffer_size,
             usage: wgpu::BufferUsages::COPY_DST
@@ -359,9 +393,9 @@ pub async fn new(window: Window) -> Self {
         };
         let output_buffer = self.device.create_buffer(&output_buffer_desc);
         let output = &self.canvas_texture;
-        let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: None,
-        });
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         encoder.copy_texture_to_buffer(
             wgpu::ImageCopyTexture {
                 aspect: wgpu::TextureAspect::All,
@@ -373,7 +407,9 @@ pub async fn new(window: Window) -> Self {
                 buffer: &output_buffer,
                 layout: wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(Self::get_necessary_buffer_width(utils::WINDOW_WIDTH) * u32_size),
+                    bytes_per_row: Some(
+                        Self::get_necessary_buffer_width(utils::WINDOW_WIDTH) * u32_size,
+                    ),
                     rows_per_image: None,
                 },
             },
@@ -396,57 +432,69 @@ pub async fn new(window: Window) -> Self {
             rx.receive().await.unwrap().unwrap();
 
             let data = buffer_slice.get_mapped_range();
-            image::RgbaImage::from_raw(Self::get_necessary_buffer_width(utils::WINDOW_WIDTH), utils::WINDOW_HEIGHT, data.to_vec()).unwrap()
-                            .sub_image(0,0,utils::WINDOW_WIDTH,utils::WINDOW_HEIGHT).to_image()
-
+            image::RgbaImage::from_raw(
+                Self::get_necessary_buffer_width(utils::WINDOW_WIDTH),
+                utils::WINDOW_HEIGHT,
+                data.to_vec(),
+            )
+            .unwrap()
+            .sub_image(0, 0, utils::WINDOW_WIDTH, utils::WINDOW_HEIGHT)
+            .to_image()
         }
     }
 
-    fn create_pipeline(device: &Device, format: TextureFormat,shader: ShaderModule,bind_group_layouts: &[& BindGroupLayout],buffers: &[VertexBufferLayout] ) -> RenderPipeline
-    {
+    fn create_pipeline(
+        device: &Device,
+        format: TextureFormat,
+        shader: ShaderModule,
+        bind_group_layouts: &[&BindGroupLayout],
+        buffers: &[VertexBufferLayout],
+    ) -> RenderPipeline {
         let render_pipeline_layout =
-        device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("Render Pipeline Layout"),
-            bind_group_layouts: bind_group_layouts,
-            push_constant_ranges: &[],
-        });
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: bind_group_layouts,
+                push_constant_ranges: &[],
+            });
         let screen_pipeline_fragment_target = [Some(wgpu::ColorTargetState {
-                format: format,
-                blend: Some(wgpu::BlendState::REPLACE),
-                write_mask: wgpu::ColorWrites::ALL,
+            format: format,
+            blend: Some(wgpu::BlendState::REPLACE),
+            write_mask: wgpu::ColorWrites::ALL,
         })];
         let screen_pipeline_descriptor = wgpu::RenderPipelineDescriptor {
-        label: Some("Render Pipeline"),
-        layout: Some(&render_pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: "vs_main",
-            buffers,
-        },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: "fs_main",
-            targets: &screen_pipeline_fragment_target,
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList, // 1.
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw, // 2.
-            cull_mode: Some(wgpu::Face::Back),
-            // Setting this to anything other than Fill requires Features::NON_FILL_POLYGON_MODE
-            polygon_mode: wgpu::PolygonMode::Fill,
-            // Requires Features::DEPTH_CLIP_CONTROL
-            unclipped_depth: false,
-            // Requires Features::CONSERVATIVE_RASTERIZATION
+            label: Some("Render Pipeline"),
+            layout: Some(&render_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers,
+                compilation_options: PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &screen_pipeline_fragment_target,
+                compilation_options: PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList, // 1.
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw, // 2.
+                cull_mode: Some(wgpu::Face::Back),
+                // Setting this to anything other than Fill requires Features::NON_FILL_POLYGON_MODE
+                polygon_mode: wgpu::PolygonMode::Fill,
+                // Requires Features::DEPTH_CLIP_CONTROL
+                unclipped_depth: false,
+                // Requires Features::CONSERVATIVE_RASTERIZATION
                 conservative: false,
-        },
-        depth_stencil: None, // 1.
-        multisample: wgpu::MultisampleState {
-            count: 1, // 2.
-            mask: !0, // 3.
-            alpha_to_coverage_enabled: false, // 4.
-        },
-        multiview: None, // 5.
+            },
+            depth_stencil: None, // 1.
+            multisample: wgpu::MultisampleState {
+                count: 1,                         // 2.
+                mask: !0,                         // 3.
+                alpha_to_coverage_enabled: false, // 4.
+            },
+            multiview: None, // 5.
         };
         device.create_render_pipeline(&screen_pipeline_descriptor)
     }

--- a/DoodlingCanvas/src/render_state.rs
+++ b/DoodlingCanvas/src/render_state.rs
@@ -31,6 +31,7 @@ impl Vertex {
         }
     }
 }
+
 pub struct State {
     surface: wgpu::Surface<'static>,
     device: wgpu::Device,

--- a/DoodlingCanvas/src/winit_app.rs
+++ b/DoodlingCanvas/src/winit_app.rs
@@ -116,7 +116,6 @@ impl<'a> ApplicationHandler<Events> for CanvasApp<'a> {
                 let mut renderer = rendptr.lock().unwrap();
 
                 if self.mouse_pressed {
-                    self.mouse_pressed = false;
                     let mut paint = renderer.begin_render();
                     rect.draw_to(
                         &mut renderer,

--- a/DoodlingCanvas/src/winit_app.rs
+++ b/DoodlingCanvas/src/winit_app.rs
@@ -4,10 +4,10 @@ use crate::{brush::Rectangle, render_state::State};
 use winit::{
     application::ApplicationHandler,
     dpi::PhysicalSize,
-    event::{ElementState, Event, KeyEvent, MouseButton, WindowEvent},
-    event_loop::{ActiveEventLoop, ControlFlow},
+    event::{ElementState, KeyEvent, MouseButton, WindowEvent},
+    event_loop::ActiveEventLoop,
     keyboard::{Key, NamedKey},
-    window::{Window, WindowAttributes},
+    window::Window,
 };
 
 #[derive(Debug)]
@@ -37,7 +37,8 @@ impl<'a> CanvasApp<'a> {
 impl<'a> ApplicationHandler<Events> for CanvasApp<'a> {
     fn resumed(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {
         let window_attribues = Window::default_attributes()
-            .with_inner_size(PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT));
+            .with_inner_size(PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT))
+            .with_decorations(false);
         self.window = Some(Arc::new(
             event_loop.create_window(window_attribues).unwrap(),
         ));
@@ -72,8 +73,8 @@ impl<'a> ApplicationHandler<Events> for CanvasApp<'a> {
 
     fn window_event(
         &mut self,
-        event_loop: &winit::event_loop::ActiveEventLoop,
-        window_id: winit::window::WindowId,
+        _event_loop: &winit::event_loop::ActiveEventLoop,
+        _window_id: winit::window::WindowId,
         event: winit::event::WindowEvent,
     ) {
         let mut rect = {
@@ -147,7 +148,11 @@ impl<'a> ApplicationHandler<Events> for CanvasApp<'a> {
         let _ = (event_loop, cause);
     }
 
-    fn user_event(&mut self, event_loop: &winit::event_loop::ActiveEventLoop, event: Events) {}
+    fn user_event(&mut self, _event_loop: &winit::event_loop::ActiveEventLoop, event: Events) {
+        match event {
+            Events::Close => {}
+        }
+    }
 
     fn device_event(
         &mut self,
@@ -157,7 +162,7 @@ impl<'a> ApplicationHandler<Events> for CanvasApp<'a> {
     ) {
         let _ = (event_loop, device_id, event);
     }
-    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
         let window = self.window.as_ref().unwrap();
         window.request_redraw();
     }

--- a/DoodlingCanvas/src/winit_app.rs
+++ b/DoodlingCanvas/src/winit_app.rs
@@ -1,0 +1,165 @@
+use std::sync::{Arc, Mutex};
+
+use crate::{brush::Rectangle, render_state::State};
+use winit::{
+    application::ApplicationHandler,
+    dpi::PhysicalSize,
+    event::{ElementState, Event, KeyEvent, MouseButton, WindowEvent},
+    event_loop::{ActiveEventLoop, ControlFlow},
+    keyboard::{Key, NamedKey},
+    window::{Window, WindowAttributes},
+};
+
+#[derive(Debug)]
+pub enum Events {
+    Close,
+}
+
+use crate::utils;
+
+use utils::{WINDOW_HEIGHT, WINDOW_WIDTH};
+
+#[derive(Clone, Default)]
+pub struct CanvasApp<'a> {
+    // request_redraw: bool,
+    // wait_cancelled: bool,
+    // close_requested: bool,
+    mouse_pressed: bool,
+    mouse_position: (f32, f32),
+    window: Option<Arc<Window>>,
+    pub state: Option<Arc<Mutex<State<'a>>>>,
+}
+impl<'a> CanvasApp<'a> {
+    pub fn renderer(&self) -> Arc<Mutex<State<'a>>> {
+        self.state.as_ref().unwrap().clone()
+    }
+}
+impl<'a> ApplicationHandler<Events> for CanvasApp<'a> {
+    fn resumed(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {
+        let window_attribues = Window::default_attributes()
+            .with_inner_size(PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT));
+        self.window = Some(Arc::new(
+            event_loop.create_window(window_attribues).unwrap(),
+        ));
+        self.state = Some(Arc::new(Mutex::new(pollster::block_on(State::new(
+            self.window.as_ref().unwrap().clone(),
+        )))));
+        #[cfg(target_arch = "wasm32")]
+        {
+            // Winit prevents sizing with CSS, so we have to set
+            // the size manually when on web.
+            info!("Initializing canvas");
+            use winit::platform::web::WindowExtWebSys;
+            web_sys::window()
+                .and_then(|win| win.document())
+                .and_then(|doc| {
+                    let dst = doc.get_element_by_id("wasm-example")?;
+                    let canvas = web_sys::Element::from(window.canvas());
+                    dst.append_child(&canvas).ok()?;
+                    Some(())
+                })
+                .expect("Couldn't append canvas to document body.");
+        }
+
+        self.window.as_ref().unwrap().pre_present_notify();
+        let rendptr = self.renderer();
+        let mut renderer = rendptr.lock().unwrap();
+        let mut clear_screen = renderer.begin_render();
+        renderer.clear_screen(&mut clear_screen);
+        renderer.end_render(clear_screen);
+        let _ = renderer.render();
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &winit::event_loop::ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        event: winit::event::WindowEvent,
+    ) {
+        let mut rect = {
+            let rendptr = self.renderer();
+            let mut state = rendptr.lock().unwrap();
+            Rectangle::new(&mut state, [0.0, 0.0, 10.0, 10.0])
+        };
+        match event {
+            WindowEvent::CloseRequested
+            | WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        state: ElementState::Pressed,
+                        logical_key: Key::Named(NamedKey::Escape),
+                        ..
+                    },
+                ..
+            } => {} //TODO: exit
+            WindowEvent::MouseInput {
+                button: MouseButton::Left,
+                ..
+            } => {
+                if let WindowEvent::MouseInput { state: pressed, .. } = event {
+                    self.mouse_pressed = pressed == ElementState::Pressed;
+                }
+            }
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Right,
+                ..
+            } => {}
+
+            WindowEvent::CursorMoved { position, .. } => {
+                self.mouse_position = (position.x as f32, position.y as f32);
+            }
+            WindowEvent::RedrawRequested => {
+                let window = self.window.as_ref().unwrap();
+                window.pre_present_notify();
+                let rendptr = self.renderer();
+                let mut renderer = rendptr.lock().unwrap();
+
+                if self.mouse_pressed {
+                    self.mouse_pressed = false;
+                    let mut paint = renderer.begin_render();
+                    rect.draw_to(
+                        &mut renderer,
+                        &mut paint,
+                        [self.mouse_position.0, self.mouse_position.1],
+                    );
+                    renderer.end_render(paint);
+                }
+
+                match renderer.render() {
+                    Ok(_) => {}
+                    // Reconfigure the surface if lost
+                    Err(wgpu::SurfaceError::Lost) => {}
+                    // The system is out of memory, we should probably quit
+                    Err(wgpu::SurfaceError::OutOfMemory) => unimplemented!(),
+                    // All other errors (Outdated, Timeout) should be resolved by the next frame
+                    Err(e) => eprintln!("{:?}", e),
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn new_events(
+        &mut self,
+        event_loop: &winit::event_loop::ActiveEventLoop,
+        cause: winit::event::StartCause,
+    ) {
+        let _ = (event_loop, cause);
+    }
+
+    fn user_event(&mut self, event_loop: &winit::event_loop::ActiveEventLoop, event: Events) {}
+
+    fn device_event(
+        &mut self,
+        event_loop: &winit::event_loop::ActiveEventLoop,
+        device_id: winit::event::DeviceId,
+        event: winit::event::DeviceEvent,
+    ) {
+        let _ = (event_loop, device_id, event);
+    }
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let window = self.window.as_ref().unwrap();
+        window.request_redraw();
+    }
+}

--- a/DoodlingServer/Cargo.toml
+++ b/DoodlingServer/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 async-trait = "0.1.73"
-axum = "0.7.3"
+axum = "0.7.5"
 dotenv = "0.15.0"
 env_logger = "0.10.0"
 http-body = "0.4.5"
 log = "0.4.20"
 minijinja = "1.0.7"
 serde = { version = "1.0.185", features = ["derive"] }
-surrealdb = { git = "https://github.com/surrealdb/surrealdb.git",tag ="v1.0.0"}
+surrealdb = { git = "https://github.com/surrealdb/surrealdb.git", tag = "v1.5.1" }
 tokio = { version = "1.32.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["buffer", "util", "retry", "make"] }
 tower-http = { version = "0.5.0", features = ["fs", "trace"] }

--- a/DoodlingServer/DoodlingHtmx/resources/create-doodle.html
+++ b/DoodlingServer/DoodlingHtmx/resources/create-doodle.html
@@ -12,13 +12,19 @@
         console.log("Initialized")
         let render = create_window();
         console.log("Created window")
-        window.canvas_window = WindowHandler.new(render);
+        const canvas_window = WindowHandler.new(render);
+        window.get_canvas_capture = async function get_canvas_capture() {
+            const img = await canvas_window.get_canvas_capture();
+            document.getElementById('canvas_form_data_input').value = img;
+            return img;
+        }
         await render.run_window_loop();
     </script>
 
     <input type="button" onclick="location.href='/index.html';" value="Back" class="doodle-btn" />
+    <input type="button" onclick="window.get_canvas_capture()" value="Debug" class="doodle-btn" />
 
-    <form hx-post="/api/create-doodle" hx-target="this" hx-swap="none" hx-ext='json-enc' onsubmit="document.getElementById('canvas_form_data_input').value = window.canvas_window.get_canvas_capture();">
+    <form hx-post="/api/create-doodle" hx-target="this" hx-swap="none" hx-ext='json-enc' onsubmit="window.get_canvas_capture()">
         <div class="grid grid-cols-3">
             <input type="text" name="name" placeholder="Doodle name" class="bg-gray-200" required>
             <input type="text" name="description" placeholder="Doodle description" class="bg-gray-200" required>
@@ -28,8 +34,7 @@
     </form>
 
     <div id="wasm-example" class="w-full flex justify-center items-center">
-    <canvas id="canvas" width="800" height="600"></canvas>
+        <canvas id="canvas" width="800" height="600"></canvas>
     </div>
-
 
 </div>

--- a/DoodlingServer/DoodlingHtmx/resources/create-doodle.html
+++ b/DoodlingServer/DoodlingHtmx/resources/create-doodle.html
@@ -1,16 +1,19 @@
 <script src="https://unpkg.com/htmx.org@1.9.4"></script>
 <script src="https://unpkg.com/htmx.org/dist/ext/json-enc.js"></script>
 <link href="../output.css" rel="stylesheet">
-<div id = "main" >
-     <script type="module">
-      console.log("Loading...");
-	  import init from "/pkg/DoodlingCanvas.js";
-      import {create_window}  from "/pkg/DoodlingCanvas.js";
-      import {WindowHandler} from "/pkg/DoodlingCanvas.js";
-	  await init();
-	  let render = await create_window();
-      window.canvas_window = WindowHandler.new(render);
-	  await render.run_window_loop();
+<div id="main">
+    <script type="module">
+        console.log("Loading...");
+        import init, { create_window } from "/pkg/DoodlingCanvas.js";
+        console.log("Loaded create_window")
+        import { WindowHandler } from "/pkg/DoodlingCanvas.js";
+        console.log("Loaded WindowHandler")
+        await init();
+        console.log("Initialized")
+        let render = create_window();
+        console.log("Created window")
+        window.canvas_window = WindowHandler.new(render);
+        await render.run_window_loop();
     </script>
 
     <input type="button" onclick="location.href='/index.html';" value="Back" class="doodle-btn" />
@@ -19,12 +22,14 @@
         <div class="grid grid-cols-3">
             <input type="text" name="name" placeholder="Doodle name" class="bg-gray-200" required>
             <input type="text" name="description" placeholder="Doodle description" class="bg-gray-200" required>
-            <input type="hidden" name="data" id ="canvas_form_data_input" value = "69">
-            <input type="submit" value="Create doodle" class = "doodle-btn">
+            <input type="hidden" name="data" id="canvas_form_data_input" value="69">
+            <input type="submit" value="Create doodle" class="doodle-btn">
         </div>
     </form>
 
-    <div id="wasm-example" class ="w-full flex justify-center items-center">
+    <div id="wasm-example" class="w-full flex justify-center items-center">
+    <canvas id="canvas" width="800" height="600"></canvas>
     </div>
+
 
 </div>

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   doodling-server:
     build: .
@@ -14,7 +15,7 @@ services:
       - surrealdb
 
   surrealdb:
-    image: surrealdb/surrealdb:1.0.0
+    image: surrealdb/surrealdb:latest
     command: start --user root --pass root
     ports:
       - 8000:8000

--- a/setup_canvas_asset.sh
+++ b/setup_canvas_asset.sh
@@ -1,0 +1,3 @@
+(cd DoodlingCanvas/; wasm-pack build --no-typescript --no-pack --target=web --dev)
+rm -rf DoodlingServer/DoodlingHtmx/pkg
+cp -r DoodlingCanvas/pkg DoodlingServer/DoodlingHtmx/resources/pkg


### PR DESCRIPTION
winit -> "0.28.6"
wgpu ->"0.17.0"
Winit revamped it's structure, require a separate application trait to be implemented for a struct which handles events and windows are created by the event_loop, updating required abominations like `Arc<Mutex<Option<Box<dyn Fn() -> Pin<Box<dyn Future<Output = image::RgbaImage>>>>>>>` for now, to be able to send the framebuffer from the renderer to the wasm_bingen API. 

Probably pointeless in the first case as JS pprobably has an API for extracting the canvas in the first but it was a fun experiment.